### PR TITLE
feat: allow custom scroll container (bis)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,14 @@
                     <textarea>&lt;script>window.__cmp.config.scrollPercent = .20; &lt;/script></textarea>
                 </li>
                 <li>
+                    <h4>Conteneur de scroll</h4>
+                    <p>Par défaut, le scroll est écouté sur <code>window</code>. Si un autre conteneur doit être utilisé, il est possible de l'indiquer comme ceci&nbsp;:</p>
+                    <code>// au chargement de la page</code>
+                    <textarea>&lt;script>window.__cmp.config.scrollContainer = document.getElementById("mon-conteneur"); &lt;/script></textarea>
+                    <code>// au cours du cycle de vie de l'application (SPA)</code>
+                    <textarea>&lt;script>window.__cmp("setScrollContainer", document.getElementById("mon-conteneur")); &lt;/script></textarea>
+                </li>
+                <li>
                     <h4>Texte d’explication</h4>
                     <code>// html autorisé. <br/>Exemple en <strong>Template Strings</strong></code>
                     <textarea style="height: 200px;">&lt;script>window.__cmp.config.text = 'Texte personnalisé <a href="https://www.domain.com/lien-1/" target="_blank" data-trkcmp="lien 1">lien 1</a> et <a href="https://www.domain.com/lien-2/" target="_blank" data-trkcmp="lien 2">lien 2</a>, fin du texte.';&lt;/script></textarea>

--- a/src/js/cmp.js
+++ b/src/js/cmp.js
@@ -99,6 +99,16 @@
             return ret;
         }
     };
+    // Permet de changer l'élément sur lequel on écoute le scroll
+    var _setScrollContainer = function (arg) {
+        if (arg instanceof HTMLElement) {
+            (_config.scrollContainer || window).removeEventListener('scroll', evt_scroll);
+            _config.scrollContainer = arg;
+            _config.scrollContainer.addEventListener('scroll', evt_scroll);
+            return true;
+        }
+        return false;
+    };
 
     var consent = _consent();
     var consentData;
@@ -183,6 +193,9 @@
                     return _cb_getUserConsent.push(Promise.resolve(callback));
                 }
                 callback({'consent': c}, true);
+            },
+            'setScrollContainer': function (parameter) {
+                return _setScrollContainer(parameter);
             }
         };
         if(typeof cmp[command] == 'function') {
@@ -582,8 +595,8 @@
         if(!window[cn + '_gcda']) {
             // Ecouteur Scroll
             window.evt_scroll = _throttle(function() {
-                if((window.pageYOffset || document.documentElement.scrollTop) > window.innerHeight * (_config.scrollPercent != undefined ? _config.scrollPercent : .1)) { // 10%
-                    // console.log('consent scroll');
+                var container = (_config.scrollContainer || document.documentElement);
+                if ((window.pageYOffset || container.scrollTop) > window.innerHeight * (_config.scrollPercent != undefined ? _config.scrollPercent : .1)) { // 10%
                     consentData.allowedVendorIds = consentData.vendorList.vendors.map(function(vendor){return vendor.id});
                     _setCheckbox();
                     _setVendorCheckbox();
@@ -592,7 +605,7 @@
                     window.removeEventListener('scroll', evt_scroll);
                 }
             }, 200, { trailing: true, leading: true });
-            window.addEventListener('scroll', evt_scroll);
+            (_config.scrollContainer || window).addEventListener('scroll', evt_scroll);
         }
     }
 


### PR DESCRIPTION
# Description

Permet de changer le conteneur sur lequel la CMP écoute le scroll.

# Pourquoi ?

Sur certains sites, comme l'édition du soir en mobile, le scroll n'est pas détecté par la CMP. C'est parce que la CMP écoute les évènements de scroll sur `window` et vérifie la position du scroll sur `document.documentElement`, alors que l'édition du soir mobile a un fonctionnement un peu particulier. Plusieurs articles sont affichés côte à côte (un seul visible à la fois), et on swipe horizontalement pour changer de page. Ce n'est donc pas le document qui est scrollé, mais la div de chaque article.

Il y a peut-être d'autres sites qui pourraient être impactés par cela. Ce changement est donc plutôt générique, et permet à l'utilisateur du script : 
- de déclarer le conteneur au chargement de la page
`window.__cmp.config.scrollContainer = document.getElementById("mon-conteneur");`
- de le changer au cours du cycle de vie de son application
`window.__cmp("setScrollContainer", document.getElementById("mon-conteneur"));`

## Nature du changement

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
