### PR TITLE
Fix: check if evt_scroll exists before using it

### DIFF
--- a/src/js/cmp.js
+++ b/src/js/cmp.js
@@ -101,7 +101,7 @@
     };
     // Permet de changer l'élément sur lequel on écoute le scroll
     var _setScrollContainer = function (arg) {
-        if (arg instanceof HTMLElement) {
+        if (arg instanceof HTMLElement && typeof evt_scroll !== 'undefined') {
             (_config.scrollContainer || window).removeEventListener('scroll', evt_scroll);
             _config.scrollContainer = arg;
             _config.scrollContainer.addEventListener('scroll', evt_scroll);


### PR DESCRIPTION
# Description

On s'apprête à utiliser la feature du choix du conteneur de scroll avec Twipe. Mais je constate lors de mes tests qu'une erreur se produit quand la méthode `evt_scroll` n'est pas définie. Et je vois qu'elle ne l'est pas toujours (par exemple lorsqu'on a déjà validé la CMP).

## Type of change

J'ai ajouté une condition défensive dans un `if`.

- [x] Bug fix (non-breaking change which fixes an issue)
