### PR TITLE
fix(doc): erreur dans un exemple de code

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -139,7 +139,7 @@
 
             gtag('config', 'UA-12345678-1');
         }
-    })();
+    });
 &lt;/script></textarea>
         </div>
 


### PR DESCRIPTION
Détecté grâce à un partenaire qui avait copié/collé le code sur son site, produisant une erreur.